### PR TITLE
Add fallback for browsers that do not support Clipboard API

### DIFF
--- a/src/components/App/IconView.js
+++ b/src/components/App/IconView.js
@@ -1,5 +1,6 @@
 import * as Hero from "components/heroicons"
 import React from "react"
+import copyToClipboard from "../../copyToClipboard"
 
 const IconPane = ({ outline: Outline, solid: Solid, ...props }) => {
 	const ref = React.useRef()
@@ -8,14 +9,22 @@ const IconPane = ({ outline: Outline, solid: Solid, ...props }) => {
 
 	const handleClick = e => {
 		const { outerHTML } = ref.current
-		navigator.clipboard.writeText(outerHTML).then(() => {
+		if (navigator.clipboard) {
+			navigator.clipboard.writeText(outerHTML).then(() => {
+				setText("copied!")
+				setTimeout(() => {
+					setText(props.name) // Reset
+				}, 1e3)
+			}).catch(error => {
+				console.warn({ error })
+			})
+		} else {
+			copyToClipboard(outerHTML)
 			setText("copied!")
 			setTimeout(() => {
 				setText(props.name) // Reset
 			}, 1e3)
-		}).catch(error => {
-			console.warn({ error })
-		})
+		}
 	}
 
 	const Icon = !props.prefersSolid ? Outline : Solid

--- a/src/copyToClipboard.js
+++ b/src/copyToClipboard.js
@@ -1,0 +1,25 @@
+const copyToClipboard = text => {
+	let fakeElem = document.createElement("textarea")
+	fakeElem.style.fontSize = "12pt"
+	fakeElem.style.border = "0"
+	fakeElem.style.padding = "0"
+	fakeElem.style.margin = "0"
+	fakeElem.style.position = "absolute"
+	fakeElem.style.left = "-9999px"
+
+	const yPosition = window.pageYOffset || document.documentElement.scrollTop
+	fakeElem.style.top = `${yPosition}px`
+
+	fakeElem.setAttribute("readonly", "")
+	fakeElem.value = text
+
+	document.body.appendChild(fakeElem)
+
+	fakeElem.select()
+	document.execCommand("copy")
+
+	document.body.removeChild(fakeElem)
+	fakeElem = null
+}
+
+export default copyToClipboard

--- a/src/copyToClipboard.js
+++ b/src/copyToClipboard.js
@@ -15,11 +15,23 @@ const copyToClipboard = text => {
 
 	document.body.appendChild(fakeElem)
 
-	fakeElem.select()
+	if (isIOS()) {
+		const range = document.createRange()
+		const selection = window.getSelection()
+		range.selectNodeContents(fakeElem)
+		selection.removeAllRanges()
+		selection.addRange(range)
+		fakeElem.setSelectionRange(0, 999999)
+	} else {
+		fakeElem.select()
+	}
+
 	document.execCommand("copy")
 
 	document.body.removeChild(fakeElem)
 	fakeElem = null
 }
+
+const isIOS = () => navigator.userAgent.match(/ipad|iphone/i)
 
 export default copyToClipboard


### PR DESCRIPTION
This fixes #3 by adding a fallback to `execCommand()` for browsers that do not support the Clipboard API such as Safari.

This fallback creates a `ghost` textarea with the svg code to be copied as the value. This is so we can automatically select the text and copy to clipboard using `execCommand("copy")`. This `ghost` textarea is invisible and removed immediately.