### PR TITLE
Update q-r-code name to be qrcode

### DIFF
--- a/src/App/helpers/icons.js
+++ b/src/App/helpers/icons.js
@@ -894,8 +894,8 @@ const originalIcons = [
 		statusNew: true,
 	},
 	{
-		tags: ["q-r-code", "q", "r", "code"],
-		name: "q-r-code",
+		tags: ["q-r-code", "qrcode", "q", "r", "code"],
+		name: "qrcode",
 		outline: Hero.QRCodeOutlineMd,
 		solid: Hero.QRCodeSolidSm,
 		statusNew: false,


### PR DESCRIPTION
Hello!

💁 This PR updates the name for `q-r-code` to match what is currently in https://github.com/refactoringui/heroicons.

We use heroicons.dev as a reference and [vue-heroicon](https://www.npmjs.com/package/vue-heroicon) to display Heroicons in our Vue application. Today we were trying to use `q-r-code` and came up short because the _actual_ name of the file is `qrcode.svg`. 

I'm unsure if this is the appropriate patch, but `qrcode` worked for us, so I figured I'd send a PR to possibly help others out that get lost.

Edit: I meant to link to the reference SVG in the Heroicons repository: https://github.com/refactoringui/heroicons/blob/master/solid/qrcode.svg

Thanks!