### PR TITLE
Center text below the icon correctly.

### DIFF
--- a/src/contents-search.tsx
+++ b/src/contents-search.tsx
@@ -115,7 +115,7 @@ export function SearchResults() {
 						}}>
 							<Icon className="h-32 w-32 [color]-$fill-color" style={iconStyles} name={name} />
 						</button>
-						<div className="flex justify-center align-center h-24">
+						<div className="flex justify-center align-center w-$grid-item-size h-24">
 							<styled.TypographySearchResult className="[color]-$soft-fill-color ellipsis [-webkit-user-select]-all [user-select]-all">
 								<Highlight indexes={indexes}>
 									{name}


### PR DESCRIPTION
Make sure the text field has the same width as the icon above it so the text is centred according to the icon.